### PR TITLE
[HYPERCHARGE-6]  특정 맵의 브롤러별 통계 조회 API 개발

### DIFF
--- a/hypercharge-api/src/main/kotlin/com/brawl/stars/hypercharge/api/controller/MapController.kt
+++ b/hypercharge-api/src/main/kotlin/com/brawl/stars/hypercharge/api/controller/MapController.kt
@@ -1,8 +1,10 @@
 package com.brawl.stars.hypercharge.api.controller
 
 import com.brawl.stars.hypercharge.api.dto.response.ApiResponse
+import com.brawl.stars.hypercharge.api.dto.response.BrawlerStatDto
 import com.brawl.stars.hypercharge.api.dto.response.CombinationDto
-import com.brawl.stars.hypercharge.api.service.MapCombinationService
+import com.brawl.stars.hypercharge.api.service.MapStatService
+import com.brawl.stars.hypercharge.api.support.BrawlerSortType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -13,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/maps")
 class MapController(
-    private val mapCombinationService: MapCombinationService
+    private val mapStatService: MapStatService
 ) {
 
     @GetMapping("/{mapId}/combinations")
@@ -22,7 +24,16 @@ class MapController(
         @RequestParam(defaultValue = "10") minGames: Int,
         @RequestParam(defaultValue = "20") limit: Int
     ): ResponseEntity<ApiResponse<CombinationDto>> {
-        val response = mapCombinationService.getMapCombinations(mapId, minGames, limit)
+        val response = mapStatService.getMapCombinations(mapId, minGames, limit)
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/{mapId}/brawlers")
+    fun getMapBrawlers(
+        @PathVariable mapId: String,
+        @RequestParam(defaultValue = "WIN_RATE") sort: BrawlerSortType
+    ): ResponseEntity<ApiResponse<BrawlerStatDto>> {
+        val response = mapStatService.getMapBrawlers(mapId, sort)
         return ResponseEntity.ok(response)
     }
 }

--- a/hypercharge-api/src/main/kotlin/com/brawl/stars/hypercharge/api/dto/response/BrawlerResponse.kt
+++ b/hypercharge-api/src/main/kotlin/com/brawl/stars/hypercharge/api/dto/response/BrawlerResponse.kt
@@ -1,0 +1,30 @@
+package com.brawl.stars.hypercharge.api.dto.response
+
+import com.brawl.stars.hypercharge.domain.entity.read.BrawlerCalculatedStats
+import com.brawl.stars.hypercharge.domain.support.BrawlerTier.Companion.calculateBrawlerTier
+import com.brawl.stars.hypercharge.domain.support.BrawlerType
+import java.math.BigDecimal
+
+data class BrawlerStatDto(
+    val brawlerId: String,
+    val brawlerName: String,
+    val winRate: BigDecimal,
+    val pickRate: BigDecimal,
+    val starRate: BigDecimal,
+    val totalPick: Long,
+    val totalWin: Long,
+    val tier: String,
+    val totalStarPlayer: Long
+) {
+    constructor(stats: BrawlerCalculatedStats) : this(
+        brawlerId = stats.brawler.brawlerId,
+        brawlerName = BrawlerType.fromId(stats.brawler.brawlerId).displayName,
+        winRate = stats.brawler.winRate,
+        pickRate = stats.pickRate,
+        starRate = stats.starRate,
+        totalPick = stats.brawler.totalPick,
+        totalWin = stats.brawler.totalWin,
+        tier = calculateBrawlerTier(stats.brawler.winRate).displayName,
+        totalStarPlayer = stats.brawler.totalStarPlayer
+    )
+}

--- a/hypercharge-api/src/main/kotlin/com/brawl/stars/hypercharge/api/dto/response/CombinationResponse.kt
+++ b/hypercharge-api/src/main/kotlin/com/brawl/stars/hypercharge/api/dto/response/CombinationResponse.kt
@@ -3,10 +3,6 @@ package com.brawl.stars.hypercharge.api.dto.response
 import com.brawl.stars.hypercharge.domain.entity.read.StatMapCombination
 import java.math.BigDecimal
 
-data class MapCombinationResponse(
-    val combinations: List<CombinationDto>
-)
-
 data class CombinationDto(
     val combinationHash: String,
     val brawlers: List<BrawlerDto>,

--- a/hypercharge-api/src/main/kotlin/com/brawl/stars/hypercharge/api/service/MapBrawlerService.kt
+++ b/hypercharge-api/src/main/kotlin/com/brawl/stars/hypercharge/api/service/MapBrawlerService.kt
@@ -1,0 +1,32 @@
+package com.brawl.stars.hypercharge.api.service
+
+import com.brawl.stars.hypercharge.api.dto.response.ApiResponse
+import com.brawl.stars.hypercharge.api.dto.response.BrawlerStatDto
+import com.brawl.stars.hypercharge.api.support.BrawlerSortType
+import com.brawl.stars.hypercharge.domain.entity.read.StatMapBrawlers
+import com.brawl.stars.hypercharge.domain.repository.read.StatMapBrawlerRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class MapBrawlerService(
+    private val statMapBrawlerRepository: StatMapBrawlerRepository
+) {
+
+    fun getMapBrawlers(
+        mapId: String,
+        sort: BrawlerSortType
+    ): ApiResponse<BrawlerStatDto> {
+        val brawlers = StatMapBrawlers(statMapBrawlerRepository.findByMapId(mapId))
+        val brawlerStats = brawlers.calculateStats().map { BrawlerStatDto(it) }
+
+        val sortedStats = when (sort) {
+            BrawlerSortType.WIN_RATE -> brawlerStats.sortedByDescending { it.winRate }
+            BrawlerSortType.PICK_RATE -> brawlerStats.sortedByDescending { it.pickRate }
+            BrawlerSortType.STAR_RATE -> brawlerStats.sortedByDescending { it.starRate }
+        }
+
+        return ApiResponse(sortedStats)
+    }
+}

--- a/hypercharge-api/src/main/kotlin/com/brawl/stars/hypercharge/api/service/MapCombinationService.kt
+++ b/hypercharge-api/src/main/kotlin/com/brawl/stars/hypercharge/api/service/MapCombinationService.kt
@@ -2,7 +2,6 @@ package com.brawl.stars.hypercharge.api.service
 
 import com.brawl.stars.hypercharge.api.dto.response.ApiResponse
 import com.brawl.stars.hypercharge.api.dto.response.CombinationDto
-import com.brawl.stars.hypercharge.api.dto.response.MapCombinationResponse
 import com.brawl.stars.hypercharge.domain.repository.read.StatMapCombinationRepository
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service

--- a/hypercharge-api/src/main/kotlin/com/brawl/stars/hypercharge/api/service/MapStatService.kt
+++ b/hypercharge-api/src/main/kotlin/com/brawl/stars/hypercharge/api/service/MapStatService.kt
@@ -1,0 +1,22 @@
+package com.brawl.stars.hypercharge.api.service
+
+import com.brawl.stars.hypercharge.api.dto.response.ApiResponse
+import com.brawl.stars.hypercharge.api.dto.response.BrawlerStatDto
+import com.brawl.stars.hypercharge.api.dto.response.CombinationDto
+import com.brawl.stars.hypercharge.api.support.BrawlerSortType
+import org.springframework.stereotype.Service
+
+@Service
+class MapStatService(
+    private val mapBrawlerService: MapBrawlerService,
+    private val mapCombinationService: MapCombinationService
+) {
+
+    fun getMapBrawlers(mapId: String, sort: BrawlerSortType): ApiResponse<BrawlerStatDto> {
+        return mapBrawlerService.getMapBrawlers(mapId, sort)
+    }
+
+    fun getMapCombinations(mapId: String, minGames: Int, limit: Int): ApiResponse<CombinationDto> {
+        return mapCombinationService.getMapCombinations(mapId, minGames, limit)
+    }
+}

--- a/hypercharge-api/src/main/kotlin/com/brawl/stars/hypercharge/api/support/BrawlerSortType.kt
+++ b/hypercharge-api/src/main/kotlin/com/brawl/stars/hypercharge/api/support/BrawlerSortType.kt
@@ -1,0 +1,9 @@
+package com.brawl.stars.hypercharge.api.support
+
+enum class BrawlerSortType(
+    private val description: String
+) {
+    WIN_RATE("승률 기준 정렬"),
+    PICK_RATE("픽률 기준 정렬"),
+    STAR_RATE("스타플레이어 선정율 기준 정렬"),
+}

--- a/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/entity/read/StatMapBrawlers.kt
+++ b/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/entity/read/StatMapBrawlers.kt
@@ -1,0 +1,39 @@
+package com.brawl.stars.hypercharge.domain.entity.read
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+class StatMapBrawlers(private val values: List<StatMapBrawler>) {
+
+    private val totalPicks: Long = values.sumOf { it.totalPick }
+
+    fun calculateStats(): List<BrawlerCalculatedStats> {
+        return values.map { brawler ->
+            BrawlerCalculatedStats(
+                brawler = brawler,
+                pickRate = calculatePickRate(brawler),
+                starRate = calculateStarRate(brawler)
+            )
+        }
+    }
+
+    private fun calculatePickRate(brawler: StatMapBrawler): BigDecimal {
+        if (totalPicks <= 0) return BigDecimal.ZERO
+        return BigDecimal(brawler.totalPick)
+            .multiply(BigDecimal(100))
+            .divide(BigDecimal(totalPicks), 2, RoundingMode.HALF_UP)
+    }
+
+    private fun calculateStarRate(brawler: StatMapBrawler): BigDecimal {
+        if (brawler.totalPick <= 0) return BigDecimal.ZERO
+        return BigDecimal(brawler.totalStarPlayer)
+            .multiply(BigDecimal(100))
+            .divide(BigDecimal(brawler.totalPick), 2, RoundingMode.HALF_UP)
+    }
+}
+
+data class BrawlerCalculatedStats(
+    val brawler: StatMapBrawler,
+    val pickRate: BigDecimal,
+    val starRate: BigDecimal
+)

--- a/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/support/BrawlerTier.kt
+++ b/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/support/BrawlerTier.kt
@@ -1,0 +1,30 @@
+package com.brawl.stars.hypercharge.domain.support
+
+import java.math.BigDecimal
+
+enum class BrawlerTier(
+    val displayName: String,
+    private val description: String
+) {
+    OP("OP", "승률 60% 초과"),
+    TIER_1("1T", "승률 55% ~ 60%"),
+    TIER_2("2T", "승률 50% ~ 55%"),
+    TIER_3("3T", "승률 45% ~ 50%"),
+    TIER_4("4T", "승률 45% 미만"),
+    ;
+
+    companion object {
+        private val OP_THRESHOLD = BigDecimal("60.00")
+        private val TIER_1_THRESHOLD = BigDecimal("55.00")
+        private val TIER_2_THRESHOLD = BigDecimal("50.00")
+        private val TIER_3_THRESHOLD = BigDecimal("45.00")
+
+        fun calculateBrawlerTier(winRate: BigDecimal): BrawlerTier = when {
+            winRate > OP_THRESHOLD -> OP
+            winRate > TIER_1_THRESHOLD -> TIER_1
+            winRate > TIER_2_THRESHOLD -> TIER_2
+            winRate > TIER_3_THRESHOLD -> TIER_3
+            else -> TIER_4
+        }
+    }
+}


### PR DESCRIPTION
- Add GET /api/v1/maps/{mapId}/brawlers endpoint
- Support sorting by winRate, pickRate, starRate

New files:
- BrawlerStatDto: DTO for brawler statistics with secondary constructor
- BrawlerSortType: Enum for sorting options with description field
- BrawlerTier: Enum for tier calculation (OP, 1T~4T) based on win rate
- StatMapBrawlers: First-class collection for brawler statistics
  - Encapsulates pickRate and starRate calculation logic
  - Returns BrawlerCalculatedStats with computed values
- MapBrawlerService: Service for brawler statistics
- MapStatService: Aggregate service for map statistics

Refactoring:
- Controller now references single MapStatService (aggregate pattern)
- Remove unused MapCombinationResponse class
- Apply coding conventions:
  - Use secondary constructor instead of static factory methods
  - Add private description field to enum classes
  - Encapsulate business logic in first-class collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)