### PR TITLE
[HYPERCHARGE-9] 맵별/조합별 통계 집계 및 가공 배치(Job 2) 개발

### DIFF
--- a/hypercharge-batch/src/main/kotlin/com/brawl/stars/hypercharge/batch/job/StatAggregationJobConfiguration.kt
+++ b/hypercharge-batch/src/main/kotlin/com/brawl/stars/hypercharge/batch/job/StatAggregationJobConfiguration.kt
@@ -1,0 +1,115 @@
+package com.brawl.stars.hypercharge.batch.job
+
+import com.brawl.stars.hypercharge.batch.job.listener.JobExecutionLoggingListener
+import com.brawl.stars.hypercharge.batch.job.listener.StepExecutionLoggingListener
+import com.brawl.stars.hypercharge.batch.job.processor.BrawlerStatsProcessor
+import com.brawl.stars.hypercharge.batch.job.processor.CombinationStatsProcessor
+import com.brawl.stars.hypercharge.batch.job.tasklet.ClearStatTablesTasklet
+import com.brawl.stars.hypercharge.batch.job.writer.BrawlerStatsWriter
+import com.brawl.stars.hypercharge.batch.job.writer.CombinationStatsWriter
+import com.brawl.stars.hypercharge.domain.entity.write.BattleLog
+import com.brawl.stars.hypercharge.domain.entity.write.BattleParticipants
+import com.brawl.stars.hypercharge.domain.repository.write.BattleLogRepository
+import org.springframework.batch.core.job.Job
+import org.springframework.batch.core.job.builder.JobBuilder
+import org.springframework.batch.core.job.parameters.RunIdIncrementer
+import org.springframework.batch.core.repository.JobRepository
+import org.springframework.batch.core.step.Step
+import org.springframework.batch.core.step.builder.StepBuilder
+import org.springframework.batch.infrastructure.item.data.RepositoryItemReader
+import org.springframework.batch.infrastructure.item.data.builder.RepositoryItemReaderBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.domain.Sort
+import org.springframework.transaction.PlatformTransactionManager
+import java.time.LocalDateTime
+
+@Configuration
+class StatAggregationJobConfiguration(
+    private val jobRepository: JobRepository,
+    private val transactionManager: PlatformTransactionManager,
+    private val battleLogRepository: BattleLogRepository,
+    private val clearStatTablesTasklet: ClearStatTablesTasklet,
+    private val brawlerStatsProcessor: BrawlerStatsProcessor,
+    private val brawlerStatsWriter: BrawlerStatsWriter,
+    private val combinationStatsProcessor: CombinationStatsProcessor,
+    private val combinationStatsWriter: CombinationStatsWriter,
+    private val jobExecutionLoggingListener: JobExecutionLoggingListener,
+    private val stepExecutionLoggingListener: StepExecutionLoggingListener
+) {
+    companion object {
+        private const val ROLLING_WINDOW_DAYS = 30L
+        private const val CHUNK_SIZE = 100
+    }
+
+    @Bean
+    fun statAggregationJob(): Job {
+        return JobBuilder("statAggregationJob", jobRepository)
+            .incrementer(RunIdIncrementer())
+            .listener(jobExecutionLoggingListener)
+            .start(clearStatTablesStep())
+            .next(aggregateBrawlerStatsStep())
+            .next(aggregateCombinationStatsStep())
+            .build()
+    }
+
+    @Bean
+    fun clearStatTablesStep(): Step {
+        return StepBuilder(jobRepository)
+            .tasklet(clearStatTablesTasklet, transactionManager)
+            .listener(stepExecutionLoggingListener)
+            .build()
+    }
+
+    @Bean
+    fun aggregateBrawlerStatsStep(): Step {
+        return StepBuilder(jobRepository)
+            .chunk<BattleLog, List<BattleParticipants.BrawlerStatData>>(CHUNK_SIZE)
+            .transactionManager(transactionManager)
+            .reader(brawlerStatsBattleLogReader())
+            .processor(brawlerStatsProcessor)
+            .writer(brawlerStatsWriter)
+            .listener(stepExecutionLoggingListener)
+            .build()
+    }
+
+    @Bean
+    fun aggregateCombinationStatsStep(): Step {
+        return StepBuilder(jobRepository)
+            .chunk<BattleLog, List<BattleParticipants.TeamCombinationData>>(CHUNK_SIZE)
+            .transactionManager(transactionManager)
+            .reader(combinationStatsBattleLogReader())
+            .processor(combinationStatsProcessor)
+            .writer(combinationStatsWriter)
+            .listener(stepExecutionLoggingListener)
+            .build()
+    }
+
+    @Bean
+    fun brawlerStatsBattleLogReader(): RepositoryItemReader<BattleLog> {
+        val since = LocalDateTime.now().minusDays(ROLLING_WINDOW_DAYS)
+
+        return RepositoryItemReaderBuilder<BattleLog>()
+            .name("brawlerStatsBattleLogReader")
+            .repository(battleLogRepository)
+            .methodName("findByBattleTimeGreaterThanEqual")
+            .arguments(listOf(since))
+            .sorts(mapOf("id" to Sort.Direction.ASC))
+            .pageSize(CHUNK_SIZE)
+            .build()
+    }
+
+    @Bean
+    fun combinationStatsBattleLogReader(): RepositoryItemReader<BattleLog> {
+        val since = LocalDateTime.now().minusDays(ROLLING_WINDOW_DAYS)
+
+        return RepositoryItemReaderBuilder<BattleLog>()
+            .name("combinationStatsBattleLogReader")
+            .repository(battleLogRepository)
+            .methodName("findByBattleTimeGreaterThanEqual")
+            .arguments(listOf(since))
+            .sorts(mapOf("id" to Sort.Direction.ASC))
+            .pageSize(CHUNK_SIZE)
+            .build()
+    }
+}

--- a/hypercharge-batch/src/main/kotlin/com/brawl/stars/hypercharge/batch/job/processor/BrawlerStatsProcessor.kt
+++ b/hypercharge-batch/src/main/kotlin/com/brawl/stars/hypercharge/batch/job/processor/BrawlerStatsProcessor.kt
@@ -1,0 +1,24 @@
+package com.brawl.stars.hypercharge.batch.job.processor
+
+import com.brawl.stars.hypercharge.domain.entity.write.BattleLog
+import com.brawl.stars.hypercharge.domain.entity.write.BattleParticipants
+import org.springframework.batch.infrastructure.item.ItemProcessor
+import org.springframework.stereotype.Component
+
+@Component
+class BrawlerStatsProcessor : ItemProcessor<BattleLog, List<BattleParticipants.BrawlerStatData>> {
+
+    override fun process(item: BattleLog): List<BattleParticipants.BrawlerStatData>? {
+        if (item.participants.isEmpty()) {
+            return null
+        }
+
+        val battleParticipants = BattleParticipants(
+            participants = item.participants,
+            starPlayerBrawlerId = item.starPlayerBrawlerId
+        )
+
+        val stats = battleParticipants.extractBrawlerStats(item.mapId)
+        return stats.ifEmpty { null }
+    }
+}

--- a/hypercharge-batch/src/main/kotlin/com/brawl/stars/hypercharge/batch/job/processor/CombinationStatsProcessor.kt
+++ b/hypercharge-batch/src/main/kotlin/com/brawl/stars/hypercharge/batch/job/processor/CombinationStatsProcessor.kt
@@ -1,0 +1,24 @@
+package com.brawl.stars.hypercharge.batch.job.processor
+
+import com.brawl.stars.hypercharge.domain.entity.write.BattleLog
+import com.brawl.stars.hypercharge.domain.entity.write.BattleParticipants
+import org.springframework.batch.infrastructure.item.ItemProcessor
+import org.springframework.stereotype.Component
+
+@Component
+class CombinationStatsProcessor : ItemProcessor<BattleLog, List<BattleParticipants.TeamCombinationData>> {
+
+    override fun process(item: BattleLog): List<BattleParticipants.TeamCombinationData>? {
+        if (item.participants.isEmpty()) {
+            return null
+        }
+
+        val battleParticipants = BattleParticipants(
+            participants = item.participants,
+            starPlayerBrawlerId = item.starPlayerBrawlerId
+        )
+
+        val combinations = battleParticipants.extractTeamCombinations(item.mapId)
+        return combinations.ifEmpty { null }
+    }
+}

--- a/hypercharge-batch/src/main/kotlin/com/brawl/stars/hypercharge/batch/job/tasklet/ClearStatTablesTasklet.kt
+++ b/hypercharge-batch/src/main/kotlin/com/brawl/stars/hypercharge/batch/job/tasklet/ClearStatTablesTasklet.kt
@@ -1,0 +1,29 @@
+package com.brawl.stars.hypercharge.batch.job.tasklet
+
+import com.brawl.stars.hypercharge.domain.repository.read.StatMapBrawlerRepository
+import com.brawl.stars.hypercharge.domain.repository.read.StatMapCombinationRepository
+import org.slf4j.LoggerFactory
+import org.springframework.batch.core.scope.context.ChunkContext
+import org.springframework.batch.core.step.StepContribution
+import org.springframework.batch.core.step.tasklet.Tasklet
+import org.springframework.batch.infrastructure.repeat.RepeatStatus
+import org.springframework.stereotype.Component
+
+@Component
+class ClearStatTablesTasklet(
+    private val statMapBrawlerRepository: StatMapBrawlerRepository,
+    private val statMapCombinationRepository: StatMapCombinationRepository
+) : Tasklet {
+
+    private val log = LoggerFactory.getLogger(ClearStatTablesTasklet::class.java)
+
+    override fun execute(contribution: StepContribution, chunkContext: ChunkContext): RepeatStatus {
+        statMapBrawlerRepository.deleteAll()
+        log.info("Cleared stat_map_brawler table")
+
+        statMapCombinationRepository.deleteAll()
+        log.info("Cleared stat_map_combination table")
+
+        return RepeatStatus.FINISHED
+    }
+}

--- a/hypercharge-batch/src/main/kotlin/com/brawl/stars/hypercharge/batch/job/writer/BrawlerStatsWriter.kt
+++ b/hypercharge-batch/src/main/kotlin/com/brawl/stars/hypercharge/batch/job/writer/BrawlerStatsWriter.kt
@@ -1,0 +1,67 @@
+package com.brawl.stars.hypercharge.batch.job.writer
+
+import com.brawl.stars.hypercharge.domain.entity.read.StatMapBrawler
+import com.brawl.stars.hypercharge.domain.entity.write.BattleParticipants
+import com.brawl.stars.hypercharge.domain.repository.read.StatMapBrawlerRepository
+import org.slf4j.LoggerFactory
+import org.springframework.batch.infrastructure.item.Chunk
+import org.springframework.batch.infrastructure.item.ItemWriter
+import org.springframework.stereotype.Component
+
+@Component
+class BrawlerStatsWriter(
+    private val statMapBrawlerRepository: StatMapBrawlerRepository
+) : ItemWriter<List<BattleParticipants.BrawlerStatData>> {
+
+    private val log = LoggerFactory.getLogger(BrawlerStatsWriter::class.java)
+
+    override fun write(chunk: Chunk<out List<BattleParticipants.BrawlerStatData>>) {
+        val aggregatedStats = aggregateChunkData(chunk)
+        if (aggregatedStats.isEmpty()) return
+
+        val mapIds = aggregatedStats.keys.map { it.first }.toSet()
+        val existingEntities = statMapBrawlerRepository.findByMapIdIn(mapIds)
+            .associateBy { it.mapId to it.brawlerId }
+
+        val entitiesToSave = mutableListOf<StatMapBrawler>()
+
+        aggregatedStats.forEach { (key, stats) ->
+            val (mapId, brawlerId) = key
+            val existing = existingEntities[key]
+
+            if (existing != null) {
+                existing.addBulkPicks(stats.picks, stats.wins, stats.starPlayers)
+                entitiesToSave.add(existing)
+            } else {
+                val newEntity = StatMapBrawler(mapId = mapId, brawlerId = brawlerId)
+                    .apply { addBulkPicks(stats.picks, stats.wins, stats.starPlayers) }
+                entitiesToSave.add(newEntity)
+            }
+        }
+
+        statMapBrawlerRepository.saveAll(entitiesToSave)
+        log.debug("Brawler stats - saved {} entities", entitiesToSave.size)
+    }
+
+    private fun aggregateChunkData(
+        chunk: Chunk<out List<BattleParticipants.BrawlerStatData>>
+    ): Map<Pair<String, String>, AggregatedBrawlerStats> {
+        val result = mutableMapOf<Pair<String, String>, AggregatedBrawlerStats>()
+
+        chunk.items.flatten().forEach { data ->
+            val key = data.mapId to data.brawlerId
+            val stats = result.getOrPut(key) { AggregatedBrawlerStats() }
+            stats.picks++
+            if (data.isWin) stats.wins++
+            if (data.isStarPlayer) stats.starPlayers++
+        }
+
+        return result
+    }
+
+    private class AggregatedBrawlerStats(
+        var picks: Int = 0,
+        var wins: Int = 0,
+        var starPlayers: Int = 0
+    )
+}

--- a/hypercharge-batch/src/main/kotlin/com/brawl/stars/hypercharge/batch/job/writer/CombinationStatsWriter.kt
+++ b/hypercharge-batch/src/main/kotlin/com/brawl/stars/hypercharge/batch/job/writer/CombinationStatsWriter.kt
@@ -1,0 +1,65 @@
+package com.brawl.stars.hypercharge.batch.job.writer
+
+import com.brawl.stars.hypercharge.domain.entity.read.StatMapCombination
+import com.brawl.stars.hypercharge.domain.entity.write.BattleParticipants
+import com.brawl.stars.hypercharge.domain.repository.read.StatMapCombinationRepository
+import org.slf4j.LoggerFactory
+import org.springframework.batch.infrastructure.item.Chunk
+import org.springframework.batch.infrastructure.item.ItemWriter
+import org.springframework.stereotype.Component
+
+@Component
+class CombinationStatsWriter(
+    private val statMapCombinationRepository: StatMapCombinationRepository
+) : ItemWriter<List<BattleParticipants.TeamCombinationData>> {
+
+    private val log = LoggerFactory.getLogger(CombinationStatsWriter::class.java)
+
+    override fun write(chunk: Chunk<out List<BattleParticipants.TeamCombinationData>>) {
+        val aggregatedStats = aggregateChunkData(chunk)
+        if (aggregatedStats.isEmpty()) return
+
+        val mapIds = aggregatedStats.keys.map { it.first }.toSet()
+        val existingEntities = statMapCombinationRepository.findByMapIdIn(mapIds)
+            .associateBy { it.mapId to it.brawlerIdList }
+
+        val entitiesToSave = mutableListOf<StatMapCombination>()
+
+        aggregatedStats.forEach { (key, stats) ->
+            val (mapId, brawlerIdList) = key
+            val existing = existingEntities[key]
+
+            if (existing != null) {
+                existing.addBulkGames(stats.games, stats.wins)
+                entitiesToSave.add(existing)
+            } else {
+                val newEntity = StatMapCombination(mapId = mapId, brawlerIdList = brawlerIdList)
+                    .apply { addBulkGames(stats.games, stats.wins) }
+                entitiesToSave.add(newEntity)
+            }
+        }
+
+        statMapCombinationRepository.saveAll(entitiesToSave)
+        log.debug("Combination stats - saved {} entities", entitiesToSave.size)
+    }
+
+    private fun aggregateChunkData(
+        chunk: Chunk<out List<BattleParticipants.TeamCombinationData>>
+    ): Map<Pair<String, String>, AggregatedCombinationStats> {
+        val result = mutableMapOf<Pair<String, String>, AggregatedCombinationStats>()
+
+        chunk.items.flatten().forEach { data ->
+            val key = data.mapId to data.brawlerIdList
+            val stats = result.getOrPut(key) { AggregatedCombinationStats() }
+            stats.games++
+            if (data.isWin) stats.wins++
+        }
+
+        return result
+    }
+
+    private class AggregatedCombinationStats(
+        var games: Int = 0,
+        var wins: Int = 0
+    )
+}

--- a/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/entity/read/StatMapBrawler.kt
+++ b/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/entity/read/StatMapBrawler.kt
@@ -40,4 +40,33 @@ class StatMapBrawler(
     @Column(name = "win_rate", precision = 5, scale = 2, nullable = false)
     var winRate: BigDecimal = BigDecimal.ZERO
         protected set
+
+    fun updateStats(totalPick: Long, totalWin: Long, totalStarPlayer: Long) {
+        this.totalPick = totalPick
+        this.totalWin = totalWin
+        this.totalStarPlayer = totalStarPlayer
+        this.winRate = calculateWinRate()
+    }
+
+    fun addPick(isWin: Boolean, isStarPlayer: Boolean) {
+        this.totalPick++
+        if (isWin) this.totalWin++
+        if (isStarPlayer) this.totalStarPlayer++
+        this.winRate = calculateWinRate()
+    }
+
+    fun addBulkPicks(picks: Int, wins: Int, starPlayers: Int) {
+        this.totalPick += picks
+        this.totalWin += wins
+        this.totalStarPlayer += starPlayers
+        this.winRate = calculateWinRate()
+    }
+
+    private fun calculateWinRate(): BigDecimal {
+        return if (totalPick > 0) {
+            BigDecimal(totalWin * 100).divide(BigDecimal(totalPick), 2, java.math.RoundingMode.HALF_UP)
+        } else {
+            BigDecimal.ZERO
+        }
+    }
 }

--- a/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/entity/read/StatMapCombination.kt
+++ b/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/entity/read/StatMapCombination.kt
@@ -43,4 +43,30 @@ class StatMapCombination(
             id to brawlerType.displayName
         }
     }
+
+    fun updateStats(totalGame: Long, totalWin: Long) {
+        this.totalGame = totalGame
+        this.totalWin = totalWin
+        this.winRate = calculateWinRate()
+    }
+
+    fun addGame(isWin: Boolean) {
+        this.totalGame++
+        if (isWin) this.totalWin++
+        this.winRate = calculateWinRate()
+    }
+
+    fun addBulkGames(games: Int, wins: Int) {
+        this.totalGame += games
+        this.totalWin += wins
+        this.winRate = calculateWinRate()
+    }
+
+    private fun calculateWinRate(): BigDecimal {
+        return if (totalGame > 0) {
+            BigDecimal(totalWin * 100).divide(BigDecimal(totalGame), 2, java.math.RoundingMode.HALF_UP)
+        } else {
+            BigDecimal.ZERO
+        }
+    }
 }

--- a/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/entity/write/BattleParticipants.kt
+++ b/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/entity/write/BattleParticipants.kt
@@ -1,0 +1,65 @@
+package com.brawl.stars.hypercharge.domain.entity.write
+
+import com.brawl.stars.hypercharge.domain.support.BrawlerCombinationHashGenerator
+
+class BattleParticipants(
+    private val participants: List<BattleParticipantDetail>,
+    private val starPlayerBrawlerId: String?
+) {
+    companion object {
+        private const val TEAM_SIZE = 3
+        private const val TEAM_BLUE = 0
+        private const val TEAM_RED = 1
+    }
+
+    fun extractBrawlerStats(mapId: String): List<BrawlerStatData> {
+        return participants.map { participant ->
+            BrawlerStatData(
+                mapId = mapId,
+                brawlerId = participant.brawlerId,
+                isWin = participant.isVictory,
+                isStarPlayer = participant.brawlerId == starPlayerBrawlerId
+            )
+        }
+    }
+
+    fun extractTeamCombinations(mapId: String): List<TeamCombinationData> {
+        val result = mutableListOf<TeamCombinationData>()
+
+        val blueTeam = participants.filter { it.teamCode == TEAM_BLUE }
+        val redTeam = participants.filter { it.teamCode == TEAM_RED }
+
+        if (blueTeam.size == TEAM_SIZE) {
+            result.add(createCombinationData(mapId, blueTeam))
+        }
+
+        if (redTeam.size == TEAM_SIZE) {
+            result.add(createCombinationData(mapId, redTeam))
+        }
+
+        return result
+    }
+
+    private fun createCombinationData(
+        mapId: String,
+        team: List<BattleParticipantDetail>
+    ): TeamCombinationData {
+        val brawlerIds = team.map { it.brawlerId }
+        val hash = BrawlerCombinationHashGenerator.generate(brawlerIds)
+        val isWin = team.first().isVictory
+        return TeamCombinationData(mapId, hash, isWin)
+    }
+
+    data class BrawlerStatData(
+        val mapId: String,
+        val brawlerId: String,
+        val isWin: Boolean,
+        val isStarPlayer: Boolean
+    )
+
+    data class TeamCombinationData(
+        val mapId: String,
+        val brawlerIdList: String,
+        val isWin: Boolean
+    )
+}

--- a/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/repository/read/StatMapBrawlerRepository.kt
+++ b/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/repository/read/StatMapBrawlerRepository.kt
@@ -6,4 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface StatMapBrawlerRepository : JpaRepository<StatMapBrawler, Long> {
 
     fun findByMapId(mapId: String): List<StatMapBrawler>
+
+    fun findByMapIdAndBrawlerId(mapId: String, brawlerId: String): StatMapBrawler?
+
+    fun findByMapIdIn(mapIds: Set<String>): List<StatMapBrawler>
 }

--- a/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/repository/read/StatMapCombinationRepository.kt
+++ b/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/repository/read/StatMapCombinationRepository.kt
@@ -8,6 +8,10 @@ interface StatMapCombinationRepository : JpaRepository<StatMapCombination, Long>
 
     fun findByMapId(mapId: String): List<StatMapCombination>
 
+    fun findByMapIdAndBrawlerIdList(mapId: String, brawlerIdList: String): StatMapCombination?
+
+    fun findByMapIdIn(mapIds: Set<String>): List<StatMapCombination>
+
     fun findByMapIdAndTotalGameGreaterThanEqualOrderByWinRateDesc(
         mapId: String,
         minGames: Long,

--- a/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/repository/write/BattleLogRepository.kt
+++ b/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/repository/write/BattleLogRepository.kt
@@ -1,6 +1,9 @@
 package com.brawl.stars.hypercharge.domain.repository.write
 
 import com.brawl.stars.hypercharge.domain.entity.write.BattleLog
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import java.time.LocalDateTime
 
@@ -13,4 +16,7 @@ interface BattleLogRepository : JpaRepository<BattleLog, Long> {
     ): Boolean
 
     fun findByBattleTimeBefore(cutoffDate: LocalDateTime): List<BattleLog>
+
+    @EntityGraph(attributePaths = ["participants"])
+    fun findByBattleTimeGreaterThanEqual(since: LocalDateTime, pageable: Pageable): Page<BattleLog>
 }

--- a/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/support/BrawlerCombinationHashGenerator.kt
+++ b/hypercharge-domain/src/main/kotlin/com/brawl/stars/hypercharge/domain/support/BrawlerCombinationHashGenerator.kt
@@ -1,0 +1,25 @@
+package com.brawl.stars.hypercharge.domain.support
+
+/**
+ * 브롤러 조합의 고유 해시를 생성하는 유틸리티 클래스.
+ * 휴먼 에러 방지를 위해 조합 해시 생성 로직을 단일 클래스에서 관리합니다.
+ *
+ * 정렬 전략: 브롤러 ID를 오름차순으로 정렬 후 ":" 구분자로 연결
+ * 예시: ["SHELLY", "BULL", "COLT"] -> "BULL:COLT:SHELLY"
+ */
+object BrawlerCombinationHashGenerator {
+
+    private const val DELIMITER = ":"
+    private const val TEAM_SIZE = 3
+
+    fun generate(brawlerIds: List<String>): String {
+        require(brawlerIds.size == TEAM_SIZE) {
+            "조합은 정확히 ${TEAM_SIZE}명의 브롤러로 구성되어야 합니다. 현재: ${brawlerIds.size}명"
+        }
+        return brawlerIds.sorted().joinToString(DELIMITER)
+    }
+
+    fun parse(hash: String): List<String> {
+        return hash.split(DELIMITER)
+    }
+}


### PR DESCRIPTION
30일 롤링 윈도우 기반의 맵별 브롤러/조합 통계 집계 배치를 구현합니다.
- Spring Batch Chunk 기반 처리로 브롤러별 승률/픽률/스타플레이어 선정율 집계
- BattleParticipants 일급 컬렉션으로 집계 로직 캡슐화
- Sorted ID Hash 전략으로 3인 조합 정합성 보장
- 벌크 처리 최적화로 Writer 성능 개선 (N회 → 2회 쿼리)